### PR TITLE
refactor(projects): improve filter UI and add scroll-to-top UX

### DIFF
--- a/src/components/Projects/FilterProjects.jsx
+++ b/src/components/Projects/FilterProjects.jsx
@@ -15,7 +15,7 @@ function FilterProjects({ categories, selected, onSelect }) {
                         {
                             'bg-brand text-white shadow-md':
                                 selected === category,
-                            'bg-gray-200 dark:bg-dark-20 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700':
+                            'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700':
                                 selected !== category,
                         },
                     )}

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import projectsData from '../../data/projects.json';
 import Button from '../common/Buttons/Button';
 import ProjectCard from './ProjectCard';
@@ -11,6 +11,7 @@ function Projects() {
     const [visibleProjects, setVisibleProjects] = useState(6);
     const [selectedProject, setSelectedProject] = useState(null);
     const [selectedCategory, setSelectedCategory] = useState('Todos');
+    const projectsSectionRef = useRef(null);
 
     const categories = useMemo(
         () => ['Todos', ...new Set(projectsData.map((p) => p.category))],
@@ -31,6 +32,7 @@ function Projects() {
 
     const unloadPreviousProjects = () => {
         setVisibleProjects(6);
+        projectsSectionRef.current?.scrollIntoView({ behaivor: 'smooth' });
     };
 
     const openModal = (project) => setSelectedProject(project);
@@ -40,6 +42,7 @@ function Projects() {
         <>
             <section
                 id="projects"
+                ref={projectsSectionRef}
                 className="p-mobile md:p-tablet lg:p-desktop bg-gray-50 dark:bg-dark-20">
                 <div className="w-full max-w-7xl mx-auto flex flex-col items-center">
                     <h2 id="title-section" className="title-section">


### PR DESCRIPTION
### Key Changes

-   **Scroll-to-Top on "Show Less":** Implemented a `useRef` to smoothly scroll the user back to the top of the projects section when the "Show Less" button is clicked. 
-   **Dark Mode Filter Styles:** Updated the background color for the inactive filter buttons in dark mode to provide better contrast and align more closely with the overall theme.